### PR TITLE
[fix] fasta file name in blastdb generation

### DIFF
--- a/flams/databases/setup.py
+++ b/flams/databases/setup.py
@@ -81,7 +81,7 @@ def _generate_blastdb(data_dir, modification: ModificationType):
             modification.type, modification.version
         )
         subprocess.call(
-            f'cd "{data_dir}" && makeblastdb -in {modification.type}.fasta -dbtype prot -input_type fasta -parse_seqids'
+            f'cd "{data_dir}" && makeblastdb -in {modification.type}-{modification.version}.fasta -dbtype prot -input_type fasta -parse_seqids'
             f" -out {out_db_name}",
             shell=True,
         )

--- a/flams/databases/setup.py
+++ b/flams/databases/setup.py
@@ -81,7 +81,8 @@ def _generate_blastdb(data_dir, modification: ModificationType):
             modification.type, modification.version
         )
         subprocess.call(
-            f'cd "{data_dir}" && makeblastdb -in {modification.type}-{modification.version}.fasta -dbtype prot -input_type fasta -parse_seqids'
+            f'cd "{data_dir}" && makeblastdb -in {modification.type}-{modification.version}.fasta '
+            f'-dbtype prot -input_type fasta -parse_seqids'
             f" -out {out_db_name}",
             shell=True,
         )


### PR DESCRIPTION
the fasta file name was not changed everywhere in https://github.com/annkamsk/flams/pull/18 and went unnoticed when merging the PR...