### PR TITLE
Update README + fix output file absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Optional arguments:
 
 Example:
 
-`python -m flams.main --in P57703.fa --range 5 -o results.tsv -m acetylation succinylation 308`
+`python -m flams.main --in P57703.fa --range 5 -o results.tsv 308 -m acetylation succinylation`
 
-`python -m flams.main --id P57703 -m lactylation 19`
+`python -m flams.main --id P57703 19 -m lactylation`
 
 
 # Development

--- a/flams/main.py
+++ b/flams/main.py
@@ -13,6 +13,9 @@ DATA_PATH = Path(__file__).parents[1] / "data"
 def main(args, protein_file):
     update_db_for_modifications(args.modification)
 
+    # Save absolute path to output file, because run_blast will change working directory.
+    output_file = args.output.absolute()
+
     result = run_blast(
         input=protein_file,
         modifications=args.modification,
@@ -21,7 +24,7 @@ def main(args, protein_file):
         num_threads=args.num_threads,
     )
 
-    display_result(output_filename=args.output, blast_records=result)
+    display_result(output_filename=output_file, blast_records=result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* README: lysine position cannot be listed after modification types, because the position would be interpreted as a modification as well, and an error is thrown.
* output file name: run_blast changes working directory to app data dir. We need to change the path to output file into an absolute path, in order to save the file in the correct folder and not in app data dir.